### PR TITLE
Replaced topenv with pkg_env

### DIFF
--- a/R/src_impala.R
+++ b/R/src_impala.R
@@ -181,20 +181,20 @@ src_impala <- function(drv, ..., auto_disconnect = FALSE) {
   info$package <-
     attr(attr(getClass(class(con)[1]), "className"), "package")
 
-  if (isClass("impala_connection", where = topenv(parent.frame()))) {
-    removeClass("impala_connection", where = topenv(parent.frame()))
+  if (isClass("impala_connection", where = .GlobalEnv)) {
+    removeClass("impala_connection", where = .GlobalEnv)
     # TBD: issue warning?
   }
   setClass("impala_connection",
            contains = class(con),
-           where = topenv(parent.frame()))
+           where = .GlobalEnv)
 
   if(existsMethod("dbSendQuery",
                   c("impala_connection", "character"),
-                  where = topenv(parent.frame()))) {
+                  where = .GlobalEnv)) {
     removeMethod("dbSendQuery",
                  c("impala_connection", "character"),
-                 where = topenv(parent.frame()))
+                 where = .GlobalEnv)
     # TBD: issue warning?
   }
   setMethod("dbSendQuery", c("impala_connection", "character"), function(conn, statement, ...) {
@@ -206,14 +206,14 @@ src_impala <- function(drv, ..., auto_disconnect = FALSE) {
       pkg_env$order_by_in_subquery <- FALSE
     }
     result
-  }, where = topenv(parent.frame()))
+  }, where = .GlobalEnv)
 
   if (existsMethod("dbExecute",
                    c("impala_connection", "character"),
-                   where = topenv(parent.frame()))) {
+                   where = .GlobalEnv)) {
     removeMethod("dbExecute",
                  c("impala_connection", "character"),
-                 where = topenv(parent.frame()))
+                 where = .GlobalEnv)
     # TBD: issue warning?
   }
   setMethod("dbExecute", c("impala_connection", "character"), function(conn, statement, ...) {
@@ -228,7 +228,7 @@ src_impala <- function(drv, ..., auto_disconnect = FALSE) {
       pkg_env$order_by_in_subquery <- FALSE
     }
     result
-  }, where = topenv(parent.frame()))
+  }, where = .GlobalEnv)
 
   con <- structure(con, class = c("impala_connection", class(con)))
   attributes(con)$info <- info

--- a/tests/testthat/test-readme.R
+++ b/tests/testthat/test-readme.R
@@ -42,6 +42,7 @@ test_that("result from third example in README (with some tweaks) is consistent 
 })
 
 test_that("result from fourth example in README (with some tweaks) is consistent with result on tbl_df", {
+  check_impala()
   test_op <- function(x, y) {
     x %>% inner_join(y, by = "carrier") %>%
       arrange(year, month, day, carrier, flight) %>%
@@ -58,6 +59,7 @@ test_that("result from fourth example in README (with some tweaks) is consistent
 })
 
 test_that("result from fifth example in README (with some tweaks) is consistent with result on tbl_df", {
+  check_impala()
   test_op <- function(x, y) {
     y <- y %>% filter(name == "Southwest Airlines Co.")
     x %>%


### PR DESCRIPTION
Thanks for the implyr package. When trying to wrap the calls into another package for convenience, I got an error message about 'cannot add bindings to a locked environment'.

After reading the options here: [https://groups.google.com/forum/#!topic/rdevtools/tavgQCEomJ8]( https://groups.google.com/forum/#!topic/rdevtools/tavgQCEomJ8) , I decided to change the topenv calls to use the pkg_env you created at the top of the script.

This fixed my packaging issue. Can we apply this change to your repo? Thanks.